### PR TITLE
Updated LatestLap logic to have it build the initial map when it was …

### DIFF
--- a/src/main/java/f1/data/parse/packets/handlers/ParticipantPacketHandler.java
+++ b/src/main/java/f1/data/parse/packets/handlers/ParticipantPacketHandler.java
@@ -56,12 +56,12 @@ public class ParticipantPacketHandler implements PacketHandler {
                 this.participants.put(i, new TelemetryData(pd));
                 //If race number isn't greater than 0 then its not an actual participant but a placeholder, so don't add to the list.
                 if (pd.raceNumber() > 0) {
+                    this.participantDataList.add(pd);
                     if (driverPairPerTeam.containsKey(pd.teamId())) {
                         driverPairPerTeam.get(pd.teamId()).setDriverTwo(pd.driverId());
                     } else {
                         driverPairPerTeam.put(pd.teamId(), new DriverPair(pd.driverId()));
                     }
-                    this.participantDataList.add(pd);
                     if (this.driverDataDTO != null)
                         driverDataDTO.accept(new DriverDataDTO(pd.driverId(), pd.lastName()));
                 }
@@ -73,7 +73,7 @@ public class ParticipantPacketHandler implements PacketHandler {
                 DriverPair driverPair = driverPairPerTeam.get(playerDriver.teamId());
                 //Teammate driver ID will be whatever id on the driver pair isn't the players driver id.
                 final int teamMateDriverId = (playerDriverId == driverPair.getDriverOne()) ? driverPair.getDriverTwo() : driverPair.getDriverOne();
-                this.sessionChangeDTO.accept(new SessionChangeDTO(playerDriverId, teamMateDriverId, this.numActiveCars));
+                this.sessionChangeDTO.accept(new SessionChangeDTO(playerDriverId, teamMateDriverId, this.numActiveCars, this.participantDataList));
             }
         }
     }

--- a/src/main/java/f1/data/ui/F1DataUI.java
+++ b/src/main/java/f1/data/ui/F1DataUI.java
@@ -47,7 +47,7 @@ public class F1DataUI extends Application {
             AtomicInteger numActiveCars = new AtomicInteger(initResult.getNumActiveCars());
 
             //Main content panels for the different views.
-            LatestLapStageManager latestLap = new LatestLapStageManager(playerDriverId.get(), teamMateDriverId.get());
+            LatestLapStageManager latestLap = new LatestLapStageManager(playerDriverId.get(), teamMateDriverId.get(), initResult.getParticipantData());
             AllLapStageManager allLaps = new AllLapStageManager(playerDriverId.get(), teamMateDriverId.get());
             SetupStageManager setupData = new SetupStageManager();
             RunDataStageManager runData = new RunDataStageManager(playerDriverId.get(), teamMateDriverId.get(), isF1.get());
@@ -73,6 +73,7 @@ public class F1DataUI extends Application {
 
                     //Call panel specific logic for session change.
                     speedTrapData.onSessionChangeNumActiveCars(numActiveCars.get());
+                    latestLap.onSessionChange(snapshot.participantData());
                 });
             };
             //Logic for the Setup, LatestLap, and AllLap panels.

--- a/src/main/java/f1/data/ui/panels/dashboards/LatestLapDashboard.java
+++ b/src/main/java/f1/data/ui/panels/dashboards/LatestLapDashboard.java
@@ -11,6 +11,7 @@ public class LatestLapDashboard extends HBox {
     public static final int[] HEADERS_WIDTH = {155, 55, 100, 100, 100, 100};
 
     public LatestLapDashboard(String lastName) {
+        this.lastName = lastName;
         this.name = new Label(lastName);
         this.name.setMinWidth(HEADERS_WIDTH[0]);
         this.name.setTextFill(Color.WHITE);
@@ -34,12 +35,18 @@ public class LatestLapDashboard extends HBox {
         this.getChildren().addAll(name, lapNum, s1, s2, s3, lapTime);
     }
 
+    private final String lastName;
+
     private final Label name;
     private final Label lapNum;
     private final Label s1;
     private final Label s2;
     private final Label s3;
     private final Label lapTime;
+
+    public String getLastName() {
+        return lastName;
+    }
 
     public Label getName() {
         return name;

--- a/src/main/java/f1/data/ui/panels/dto/SessionChangeDTO.java
+++ b/src/main/java/f1/data/ui/panels/dto/SessionChangeDTO.java
@@ -1,4 +1,8 @@
 package f1.data.ui.panels.dto;
 
-public record SessionChangeDTO(int playerDriverId, int teamMateDriverId, int numActiveCars) {
+import f1.data.parse.packets.ParticipantData;
+
+import java.util.List;
+
+public record SessionChangeDTO(int playerDriverId, int teamMateDriverId, int numActiveCars, List<ParticipantData> participantData) {
 }


### PR DESCRIPTION
…first created, and then sort it before displaying anything on the panel. This ensures the latestLap panel is always sorted by driver last name ascending. Removed old logic in the update method. Updated logic on SessionChange to use the two new methods. Updated the ParticipantPacket logic to pass the updated Participants list to the DTO consumer on a session change